### PR TITLE
Support csvlint 0.4

### DIFF
--- a/cid.gemspec
+++ b/cid.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "csvlint"
+  spec.add_dependency "csvlint", "~> 0.4"
   spec.add_dependency "colorize"
   spec.add_dependency "json"
   spec.add_dependency "git"

--- a/lib/cid/validation.rb
+++ b/lib/cid/validation.rb
@@ -13,7 +13,7 @@ module Cid
         next if ignore.include?(path.split("/").last)
 
         if File.file?("#{path}schema.json")
-          schema = Csvlint::Schema.load_from_json_table(File.new(Dir["#{path}schema.json"][0]))
+          schema = Csvlint::Schema.load_from_json(File.new(Dir["#{path}schema.json"][0]))
         else
           schema = nil
         end
@@ -23,7 +23,7 @@ module Cid
 
           schema = Cid::Datapackage.new(root_path).schema_for_file(ref) if schema.nil?
 
-          validator = Csvlint::Validator.new(File.new(csv), nil, schema)
+          validator = Csvlint::Validator.new(File.new(csv), {}, schema)
 
           result[ref] = {}
 


### PR DESCRIPTION
`cid` doesn't work with changes to csvlint for versions at least above 0.3. This PR fixes those issues and gets `cid` working again.